### PR TITLE
Add special handling of nonzero constraints

### DIFF
--- a/plonkish_backend/src/backend/hyperplonk/preprocessor.rs
+++ b/plonkish_backend/src/backend/hyperplonk/preprocessor.rs
@@ -157,7 +157,12 @@ pub(crate) fn compose<F: PrimeField>(
 
         let eq = Expression::eq_xy(0);
 
-        let nonzero_expression = Expression::distribute_powers(nonzero_constraints, alpha); //nonzero_constraints.into_iter().sum::<Expression<_>>();
+        let nonzero_expression = if nonzero_constraints.len() > 1 {
+            nonzero_constraints.into_iter().sum::<Expression<_>>()
+        } else {
+            nonzero_constraints[0].clone()
+        };
+
         let zero_check_on_every_row = Expression::distribute_powers(valid_constraints, alpha) * eq;
         Expression::distribute_powers(
             chain![


### PR DESCRIPTION
During the preprocessing phase the plonkish backend is constructing the full SNARK expression that will later be "sumchecked" (actually, zero-checked using the sumcheck protocol). Normally, the expression represents the circuit wiring, lookups, etc., and also custom gates. In Halo2 frontend custom gates are normally represented as expressions that are zero on the evaluation domain. E.g., if the goal is to constrain `a` to be equal to `b`, the gate looks like `a - b = 0`. In this hyperplonk implementation such Halo2 gates are included into the final SNARK expression as a random linear combination of ["zero checks on every row"](https://github.com/summa-dev/plonkish/blob/303cf244803ea56d1ac8c24829ec4c67e4e798ab/plonkish_backend/src/backend/hyperplonk/preprocessor.rs#L134). For example, if the gate is `a - b = 0`, the circuit may look something like this:

|Col|a|b|Constraint eq.|
|-|-|-|-|
|Row0|3|3|3-3=0|
|Row1|5|5|5-5=0|

The important point here is that each row is checked independently due to the random linear combination of constraints (see the link above). This is essential for regular use cases where each row represents some mathematical identity of interest. After the ["distribute powers" operation and multiplication by `eq`](https://github.com/summa-dev/plonkish/blob/303cf244803ea56d1ac8c24829ec4c67e4e798ab/plonkish_backend/src/backend/hyperplonk/preprocessor.rs#L134C2-L134C17) the linear combination of constraints may look like this: `(3-3) + rnd_num * (5-5) = 0`. Meanwhile, in our case each row is simply a user balance value (let's not take the range check into account for a moment). We would benefit from a "vertical" constraint "along the column", but applying it directly using large rotations is not feasible. Instead, we can modify the plonkish backend logic to allow for special expressions that are excluded from random linear combination with `eq` and, therefore, summed directly. For example, if we want to prove the sum of two balances `3` and `5` being equal to `8`, our desired circuit may look like the following: 

|Col|Balance|
|-|-|
|Row0|3|
|Row1|5|
|Row2|-8|

As you can see, if we had a way to transform such circuit into an expression by directly querying and summing the cells, we would satisfy a sumcheck of `5 + 3 = -8`. The little trick here is to put the negative grand total at the last row.

This pull request enables the plonkish backend to construct such nonzero expression by handling nonzero gates in a special way. A nonzero gate is a Halo2 gate that would be considered invalid in a typical Halo2 circuit because its expression does not evaluate to zero. For example, 
```rust
meta.create_gate("Nonzero gate", |meta| {
                let mut nonzero_constraint: Vec<halo2_proofs::plonk::Expression<Fp>> = vec![];
                nonzero_constraint.push(meta.query_advice(balance, Rotation::cur()));
                nonzero_constraint
            });
```
As you can see, the `nonzero_constraint` here is just the query to a single cell. In the plonkish backend we can detect such a constraint by parsing the expression and observing that it does not have any arithmetic operations (this is a simple approach I came up with, although it's definitely not exhaustive). Then, we can [exclude](https://github.com/summa-dev/plonkish/blob/c9dc12571d4a9aa06a419598ff2422b42770ae91/plonkish_backend/src/backend/hyperplonk/preprocessor.rs#L136) this nonzero constraint from random linear combination.

Note that the gate defines a single expression that holds along all the rows of involved columns. If we have multiple currencies with respective negative totals in the last row, we may combine their nonzero expressions into one sum across the columns. Consider the following circuit:

|Col|Balance0|Balance1|
|-|-|-|
|Row0|3|2|
|Row1|5|7|
|Row2|-8|-9|

If we combine the column nonzero expressions when including them into sumcheck, it will look like the following: `(3+2)+(5+7)+(-8-9)=0`, and the identity still holds.